### PR TITLE
Added missing Type Name sub-objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ Literal value in the form of a plain-text.
       "name": null,
       "base": {
         "typeSpecification": {
-          "name": "object"
+          "name": {
+            "name": "object"
+          }
         }
       },
       "sections": [
@@ -281,7 +283,9 @@ Literal value in the form of a plain-text.
                 "valueDefinition": {
                   "typeDefinition": {
                     "typeSpecification": {
-                      "name": "array"
+                      "name": {
+                        "name": "array"
+                      }
                     }
                   }
                 },


### PR DESCRIPTION
Follow up to #6. In README example there are several _Type Name_ sub-objects missing on places where they should be present according to the spec. Aim of this PR is to fix this.
